### PR TITLE
Handle include patterns as additive filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ python main.py <repo-url-or-path> \
 Key options:
 
 - `--copy {map|code|both}` will push the generated outputs into the system clipboard, ready for pasting into your AI chat.
-- `.gptignore` / `.gptinclude` files (at the repo root or supplied via `--gptignore` / `--gptinclude`) mirror the patterns used by popular alternatives such as git2gpt.
+- `.gptignore` / `.gptinclude` files (at the repo root or supplied via `--gptignore` / `--gptinclude`) mirror the patterns used by popular alternatives such as git2gpt. Include patterns **add** to the default code-centric filter: code files remain eligible even when a `.gptinclude` exists, while non-code files require a matching include rule.
 - `--extra-ignore`, `--extra-include`, and `--extra-extensions` let you fine-tune experiment-specific filters without editing dotfiles.
 - `--max-file-bytes` (default 500 KB) prevents enormous compiled or vendor files from exploding the output; pass `0` to disable.
 - `--include-all` reverts to the legacy “include everything” behaviour if you really need it.

--- a/main.py
+++ b/main.py
@@ -264,6 +264,12 @@ def matches_patterns(path: str, patterns: Iterable[str]) -> bool:
     return any(posix_path.match(pattern) for pattern in patterns)
 
 
+def matches_include(path: str, include_patterns: Iterable[str]) -> bool:
+    """Return ``True`` if ``path`` is explicitly requested by include patterns."""
+
+    return matches_patterns(path, include_patterns)
+
+
 def load_pattern_file(path: Path) -> List[str]:
     patterns: List[str] = []
     if not path.exists():
@@ -339,8 +345,8 @@ def should_include_file(relative_path: str, file_name: str, options: ProcessingO
     posix = normalize_relative_path(relative_path)
     if matches_patterns(posix, options.ignore_patterns):
         return False
-    if options.include_patterns:
-        return matches_patterns(posix, options.include_patterns)
+    if matches_include(posix, options.include_patterns):
+        return True
     if options.allow_non_code:
         return True
     return is_code_file(file_name, options)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import (
+    ALWAYS_INCLUDE_FILENAMES,
+    DEFAULT_CODE_EXTENSIONS,
+    ProcessingOptions,
+    matches_include,
+    should_include_file,
+)
+
+
+@pytest.fixture
+def base_options():
+    return ProcessingOptions(
+        ignore_patterns=[],
+        include_patterns=["docs/**"],
+        allowed_extensions={ext.lower() for ext in DEFAULT_CODE_EXTENSIONS},
+        special_filenames=ALWAYS_INCLUDE_FILENAMES,
+        max_file_bytes=None,
+        allow_non_code=False,
+    )
+
+
+def test_code_files_still_included_with_include_patterns(base_options):
+    assert should_include_file("src/app.py", "app.py", base_options)
+
+
+def test_non_code_files_require_include_match(base_options):
+    assert not should_include_file("notes.txt", "notes.txt", base_options)
+    assert should_include_file("docs/notes.txt", "notes.txt", base_options)
+
+
+def test_matches_include_helper_respects_patterns(base_options):
+    assert matches_include("docs/diagram.png", base_options.include_patterns)
+    assert not matches_include("images/diagram.png", base_options.include_patterns)


### PR DESCRIPTION
## Summary
- make include-pattern matching additive so code files remain eligible by default
- add regression coverage for include/ignore combinations and expose the helper
- document the clarified include-pattern behaviour in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69024776176483218390d9877f92a54e