### PR TITLE
Add token chunking support and token statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,33 @@ Key options:
 - `--extra-ignore`, `--extra-include`, and `--extra-extensions` let you fine-tune experiment-specific filters without editing dotfiles.
 - `--max-file-bytes` (default 500 KB) prevents enormous compiled or vendor files from exploding the output; pass `0` to disable.
 - `--include-all` reverts to the legacy “include everything” behaviour if you really need it.
+- `--enable-token-counts` prints an estimated token budget for each consolidated chunk; install the optional `tiktoken` package for model-aware counts.
+- `--chunk-size` splits the consolidated output into numbered files once a chunk nears the requested token ceiling (set to `0` to disable).
 
 Repo2GPT writes `repomap.txt` and `consolidated_code.txt` to your current working directory unless you override the paths. If the targets live inside the repository directory, they are automatically excluded from the generated output.
+
+### Token planning & chunked output
+
+Install the optional tokenizer dependency to obtain model-compatible counts:
+
+```bash
+pip install tiktoken
+```
+
+Then invoke Repo2GPT with the token helpers enabled:
+
+```bash
+python main.py <repo-url-or-path> \
+  --enable-token-counts \
+  --chunk-size 3500
+```
+
+The CLI now reports token usage per chunk, the total estimated budget, and whether the counts are approximate (when `tiktoken` is unavailable). When chunking is enabled, the primary consolidated file retains its original name and subsequent chunks are written as `<name>_partXX.ext`. Clipboard copies combine the numbered chunks with lightweight headings so you can paste the full series into your prompt workflow.
 
 ## Future plans
 
 - Add ASM traversal and mapping similar to ctags.
 - Ship a web version or VS Code extension.
-- Add token estimates and chunked output helpers for extra-long repositories.
 - Better language-specific parsers for the repo map summaries.
 
 ## License

--- a/tests/test_token_counts.py
+++ b/tests/test_token_counts.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import (
+    ALWAYS_INCLUDE_FILENAMES,
+    ProcessingOptions,
+    TokenEstimator,
+    generate_consolidated_file,
+)
+
+
+def _make_options() -> ProcessingOptions:
+    return ProcessingOptions(
+        ignore_patterns=[],
+        include_patterns=[],
+        allowed_extensions={".py"},
+        special_filenames=ALWAYS_INCLUDE_FILENAMES,
+        max_file_bytes=None,
+        allow_non_code=False,
+    )
+
+
+def test_generate_consolidated_file_without_chunking(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    (repo_dir / "example.py").write_text("print('hello world')\n", encoding="utf-8")
+
+    output_path = tmp_path / "consolidated.txt"
+    results = generate_consolidated_file(
+        str(repo_dir),
+        str(output_path),
+        _make_options(),
+        set(),
+        token_estimator=TokenEstimator(enabled=False),
+    )
+
+    assert len(results) == 1
+    assert Path(results[0].path).exists()
+    assert results[0].token_count == 0
+    assert results[0].file_count == 1
+
+
+def test_generate_consolidated_file_with_chunking(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    for index in range(3):
+        (repo_dir / f"file_{index}.py").write_text(
+            "\n".join([f"print('line {index}-{i}')" for i in range(20)]),
+            encoding="utf-8",
+        )
+
+    output_path = tmp_path / "consolidated.txt"
+    estimator = TokenEstimator(enabled=True)
+    results = generate_consolidated_file(
+        str(repo_dir),
+        str(output_path),
+        _make_options(),
+        set(),
+        token_estimator=estimator,
+        chunk_token_limit=10,
+    )
+
+    assert len(results) > 1
+    assert results[0].path == str(output_path)
+    assert Path(results[0].path).exists()
+    assert Path(results[1].path).name.startswith(f"{output_path.stem}_part")
+    assert sum(chunk.file_count for chunk in results) == 3
+    assert all(Path(chunk.path).exists() for chunk in results)


### PR DESCRIPTION
## Summary
- add optional tiktoken-powered token estimator with chunked consolidated output generation
- surface token statistics in the CLI and enhance clipboard handling for multi-chunk exports
- document token planning workflow and cover chunking logic with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69026e8996808321bcf10f8828060ddb