### PR TITLE
Add pytest coverage for helper utilities and integration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ With the virtual environment activated (optional), install the packages listed i
 pip install -r requirements.txt
 ```
 
+## Running tests
+
+Repo2GPT includes a pytest suite that covers critical helpers and a full repository processing path. After installing the
+dependencies, run:
+
+```bash
+pytest
+```
+
+Use the same command in continuous integration jobs once dependency installation has completed.
+
 ## Usage
 
 With everything set up, you can now use Repo2GPT:

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Set, Tuple
 
 from git import GitCommandError, Repo
 from urllib.parse import urlparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 gitpython==3.1.24
 pyperclip==1.8.2
+pytest==8.1.1
 

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import (  # noqa: E402
+    ALWAYS_INCLUDE_FILENAMES,
+    ProcessingOptions,
+    is_binary_file,
+    resolve_skip_paths,
+    should_include_file,
+)
+
+
+def _make_options(**overrides) -> ProcessingOptions:
+    options = ProcessingOptions(
+        ignore_patterns=["ignored/**"],
+        include_patterns=["docs/**"],
+        allowed_extensions={".py", ".txt"},
+        special_filenames=ALWAYS_INCLUDE_FILENAMES,
+        max_file_bytes=None,
+        allow_non_code=False,
+    )
+    for key, value in overrides.items():
+        setattr(options, key, value)
+    return options
+
+
+def test_should_include_respects_ignore_and_extensions():
+    options = _make_options()
+
+    assert should_include_file("src/app.py", "app.py", options)
+    assert not should_include_file("ignored/app.py", "app.py", options)
+    assert should_include_file("docs/readme.md", "readme.md", options)
+    assert not should_include_file("notes/data.bin", "data.bin", options)
+
+
+def test_should_include_allows_non_code_when_requested():
+    options = _make_options(allow_non_code=True)
+
+    assert should_include_file("notes/todo.md", "todo.md", options)
+    assert not should_include_file("ignored/todo.md", "todo.md", options)
+
+
+def test_resolve_skip_paths_filters_outside_targets(tmp_path: Path):
+    local_dir = tmp_path / "repo"
+    local_dir.mkdir()
+
+    inside = local_dir / "repomap.txt"
+    inside.write_text("", encoding="utf-8")
+    nested = local_dir / "outputs" / "consolidated.txt"
+    nested.parent.mkdir()
+    nested.write_text("", encoding="utf-8")
+
+    outside = tmp_path / "external.txt"
+    outside.write_text("", encoding="utf-8")
+
+    skip = resolve_skip_paths(str(local_dir), [str(inside), str(nested), str(outside)])
+
+    assert skip == {"repomap.txt", "outputs/consolidated.txt"}
+
+
+def test_is_binary_file_detects_binary_and_missing(tmp_path: Path):
+    text_file = tmp_path / "plain.txt"
+    text_file.write_text("hello", encoding="utf-8")
+
+    binary_file = tmp_path / "data.bin"
+    binary_file.write_bytes(b"\x00\x01\x02")
+
+    missing_file = tmp_path / "missing.bin"
+
+    assert not is_binary_file(str(text_file))
+    assert is_binary_file(str(binary_file))
+    assert is_binary_file(str(missing_file))
+

--- a/tests/test_process_repository_integration.py
+++ b/tests/test_process_repository_integration.py
@@ -1,0 +1,65 @@
+import argparse
+from pathlib import Path
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import (  # noqa: E402
+    DEFAULT_MAX_FILE_BYTES,
+    process_repository,
+)
+
+
+def _build_args(repomap_path: Path, consolidated_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        repomap=str(repomap_path),
+        consolidated=str(consolidated_path),
+        gptignore=None,
+        gptinclude=None,
+        extra_ignore=None,
+        extra_include=None,
+        extra_extensions=None,
+        max_file_bytes=DEFAULT_MAX_FILE_BYTES,
+        include_all=False,
+        enable_token_counts=False,
+        chunk_size=0,
+        copy=None,
+    )
+
+
+def test_process_repository_generates_expected_outputs(tmp_path: Path):
+    repo_dir = tmp_path / "sample_repo"
+    src_dir = repo_dir / "src"
+    src_dir.mkdir(parents=True)
+
+    (src_dir / "module.py").write_text(
+        "def greet():\n    return 'hi'\n",
+        encoding="utf-8",
+    )
+    (repo_dir / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+    (repo_dir / "binary.dat").write_bytes(b"\x00\x01\x02")
+
+    repomap_path = repo_dir / "repomap.txt"
+    consolidated_path = repo_dir / "consolidated_code.txt"
+
+    args = _build_args(repomap_path, consolidated_path)
+    result = process_repository(str(repo_dir), args)
+
+    repomap_content = Path(result.repomap_path).read_text(encoding="utf-8")
+    consolidated_content = Path(result.consolidated_chunks[0].path).read_text(
+        encoding="utf-8"
+    )
+
+    assert repomap_content.splitlines()[0] == repo_dir.name
+    assert "module.py" in repomap_content
+    assert "README.md" not in repomap_content
+    assert "binary.dat" not in repomap_content
+    assert Path(result.repomap_path).parent == repo_dir
+
+    assert "def greet" in consolidated_content
+    assert "Sample Repo" not in consolidated_content
+    assert len(result.consolidated_chunks) == 1
+    assert Path(result.consolidated_chunks[0].path) == consolidated_path
+    assert result.consolidated_chunks[0].file_count == 1
+    assert not result.token_estimator.enabled


### PR DESCRIPTION
## Summary
- add pytest as a development dependency and document how to run the suite
- add unit tests covering helper behaviors around includes, skip paths, and binary detection
- add an integration test for `process_repository` to validate generated outputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69028bad2e2883218e107a9804380c0a