### PR TITLE
Restore root-anchored ignore pattern support

### DIFF
--- a/tests/test_ignore_patterns.py
+++ b/tests/test_ignore_patterns.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from repo2gpt.service import expand_patterns, matches_patterns  # noqa: E402
+
+
+def test_root_anchored_directory_patterns_match_repo_root():
+    patterns = expand_patterns(["/build/"])
+
+    assert matches_patterns("build", patterns)
+    assert matches_patterns("build/output.txt", patterns)
+
+
+def test_directory_patterns_match_nested_directories():
+    patterns = expand_patterns(["build/"])
+
+    assert matches_patterns("frontend/build", patterns)
+    assert matches_patterns("frontend/build/output.txt", patterns)


### PR DESCRIPTION
## Summary
- strip leading slashes when normalizing ignore patterns so root-scoped entries continue to match relative paths
- expand directory patterns with **/ prefixes to restore support for nested directory ignores
- add regression tests covering root-anchored and nested directory ignore behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6902af8434f48321ac63a24310802c3e