### PR TITLE
feat: add web dashboard for repo jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ The endpoint responds immediately with a job identifier while processing continu
 
 SSE streams emit `status`, `progress`, `chunk`, `repomap`, and `tokens` events, each carrying structured JSON data. The server keeps connections alive with heartbeat comments so browsers do not time out on long-running repositories.
 
+## Web control panel
+
+The `web/` directory hosts a Vite + React dashboard that wraps the API with a friendly interface:
+
+- Submit jobs from Git URLs, downloadable archives, or uploaded tar/zip bundles.
+- Watch live progress updates rendered from the SSE stream, including per-chunk token counts.
+- Preview the generated repo map and chunk contents, copy a shareable job link, or download the entire artifact bundle as a ZIP file.
+- Trigger a Gemini File API upload using a stored access token and view success/error feedback inline.
+
+The UI stores the API base URL, API token, and Gemini credentials in `localStorage`. To run it locally:
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+Pass the same API token that you configured on the FastAPI service. For production builds, run `npm run build` and serve the contents of `web/dist/` alongside the API (see [docs/deployment.md](docs/deployment.md) for hosting suggestions).
+
 ### Authentication
 
 Set the `REPO2GPT_API_KEY` environment variable to enforce API-key based authentication. When configured, every request must include an `X-API-Key` header that matches the configured secret. Leave the variable unset for unauthenticated local development.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,66 @@
+# Deployment guide
+
+This guide describes a minimal setup for hosting the FastAPI service (`api/server.py`) and the new Vite/React control panel (`web/`) together. Each section outlines environment variables, build commands, and routing considerations.
+
+## Shared prerequisites
+
+- Configure a persistent storage volume (or mounted disk) for the repo snapshot workspace. Set `REPO2GPT_STORAGE_ROOT` to point at that path.
+- Generate a strong API token and expose it as `REPO2GPT_API_KEY`. The web UI expects the same token during sign-in.
+- Build the web app prior to deployment:
+
+  ```bash
+  cd web
+  npm install
+  npm run build
+  ```
+
+  The compiled assets will be emitted into `web/dist/`. Serve this directory via any static hosting mechanism and reverse proxy `/api` requests to the FastAPI server.
+
+- Expose the API over HTTPS and ensure CORS allows the web origin. The FastAPI application inherits `REPO2GPT_API_KEY`; no extra configuration is required when both services share the same domain.
+
+## Google Cloud Run
+
+1. **Container image**
+   - Extend the provided `Dockerfile` to install Node.js, build the web bundle, and copy `web/dist` into the image.
+   - Serve the static assets with something lightweight (e.g., `uvicorn` + `fastapi.staticfiles` or `nginx`). Alternatively, host the UI on Firebase Hosting and run only the API on Cloud Run.
+2. **Runtime configuration**
+   - Set environment variables `REPO2GPT_API_KEY` and `REPO2GPT_STORAGE_ROOT` via the Cloud Run service configuration.
+   - Attach a Cloud Storage bucket or Filestore instance, mount it into the container, and point `REPO2GPT_STORAGE_ROOT` to the mount path to persist job artifacts.
+3. **Routing**
+   - If bundling UI + API, mount the `web/dist` assets at `/` and proxy API calls to `/api/*` → Uvicorn (e.g., by running a small ASGI app that mounts `StaticFiles(directory="web/dist", html=True)` and includes the FastAPI router under `/api`).
+
+## Render
+
+1. **Web service**
+   - Create a Render Web Service from the repository.
+   - Use a start command similar to `bash run.sh` after augmenting `run.sh` to perform `npm install && npm run build` and to serve the compiled UI (for example, via `uvicorn main:app --host 0.0.0.0 --port $PORT`).
+2. **Static site**
+   - Alternatively, provision a separate Render Static Site that runs `npm install && npm run build` in the `web/` directory and serves `web/dist`. Pair it with a Web Service running the API and configure a custom domain/subdomain for each.
+3. **Environment variables**
+   - Add `REPO2GPT_API_KEY` and `REPO2GPT_STORAGE_ROOT` (pointing to the built-in persistent disk) in the Render dashboard.
+
+## Heroku
+
+1. **Buildpack selection**
+   - Add the official Node.js buildpack first to compile the Vite bundle, then Python to install the FastAPI dependencies.
+   - Use a `heroku-postbuild` script inside `web/package.json` or a root-level `Procfile` command to run `npm install --prefix web && npm run build --prefix web` before launching the server.
+2. **Procfile**
+   - Example: `web: uvicorn main:app --host 0.0.0.0 --port $PORT`
+   - Extend `main.py` (or create a dedicated ASGI entry point) that mounts the static files from `web/dist` and includes the API router under `/api` so that Heroku serves both UI and backend from one dyno.
+3. **Persistent storage**
+   - Heroku’s ephemeral filesystem resets on each deploy. Use an S3 bucket or another external storage provider for `REPO2GPT_STORAGE_ROOT` (e.g., via `s3fs` or by overriding the job store implementation) if persistence is required.
+
+## Reverse proxy recommendations
+
+- When serving the UI and API together, prefer the following structure:
+  - `/` → static assets from `web/dist/index.html`
+  - `/assets/*` → other static resources from `web/dist`
+  - `/api/*` → FastAPI application (`api/server.py`)
+- Ensure the proxy forwards the `X-API-Key` header untouched so that SSE subscriptions and artifact downloads remain authenticated.
+- Configure HTTPS and enable HTTP/2 where possible for smoother SSE streaming.
+
+## Operational tips
+
+- Scale the API replicas cautiously; the job store currently uses disk-backed state. For multi-instance deployments, consider migrating to a shared database or object store.
+- Monitor worker CPU and memory. Repo snapshotting can be resource-intensive, especially for large archives. Cloud Run and Render allow you to select higher CPU/memory tiers per instance.
+- Surface API logs (e.g., via Cloud Logging, Render logs, or Heroku’s Logplex) to observe job progress and diagnose failures reported in the UI’s event timeline.

--- a/gitignore
+++ b/gitignore
@@ -7,5 +7,9 @@ __pycache__
 .Python
 env/
 venv/
+node_modules/
+web/node_modules/
+web/dist/
+web/.vite/
 *.log
 .ipynb_checkpoints

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>repo2GPT Control Panel</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,1852 @@
+{
+  "name": "repo2gpt-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "repo2gpt-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "jszip": "^3.10.1",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.3"
+      },
+      "devDependencies": {
+        "@types/jszip": "^3.1.10",
+        "@types/node": "^20.11.30",
+        "@types/react": "^18.2.43",
+        "@types/react-dom": "^18.2.17",
+        "@vitejs/plugin-react": "^4.2.1",
+        "typescript": "^5.3.3",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
+      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
+      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.5",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.5",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.5",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.5",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.5",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jszip": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-GFHqtQQP3R4NNuvZH3hNCYD0NbyBZ42bkN7kO3NDrU/SnvIZWMS8Bp38XCsRKBT5BXvgm0y1zqpZWp/ZkRzBzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jszip": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
+      "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.26",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
+      "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.21.tgz",
+      "integrity": "sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
+      "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.19",
+        "caniuse-lite": "^1.0.30001751",
+        "electron-to-chromium": "^1.5.238",
+        "node-releases": "^2.0.26",
+        "update-browserslist-db": "^1.1.4"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.243",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.243.tgz",
+      "integrity": "sha512-ZCphxFW3Q1TVhcgS9blfut1PX8lusVi2SvXQgmEEnK4TCmE1JhH2JkjJN+DNt0pJJwfBri5AROBnz2b/C+YU9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.5",
+        "@rollup/rollup-android-arm64": "4.52.5",
+        "@rollup/rollup-darwin-arm64": "4.52.5",
+        "@rollup/rollup-darwin-x64": "4.52.5",
+        "@rollup/rollup-freebsd-arm64": "4.52.5",
+        "@rollup/rollup-freebsd-x64": "4.52.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+        "@rollup/rollup-linux-arm64-musl": "4.52.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-musl": "4.52.5",
+        "@rollup/rollup-openharmony-arm64": "4.52.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+        "@rollup/rollup-win32-x64-gnu": "4.52.5",
+        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
+      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "repo2gpt-web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "jszip": "^3.10.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/jszip": "^3.1.10",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.43",
+    "@types/react-dom": "^18.2.17",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import {
+  Navigate,
+  Outlet,
+  Route,
+  Routes,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
+import { AppConfigProvider, useAppConfig } from "./context/AppConfigContext";
+import { Dashboard } from "./components/Dashboard";
+import { HeaderBar } from "./components/HeaderBar";
+import { SettingsPanel } from "./components/SettingsPanel";
+import { AuthPrompt } from "./components/AuthPrompt";
+import "./styles/app.css";
+
+function AppRoutes() {
+  return (
+    <Routes>
+      <Route element={<AppLayout />}>
+        <Route index element={<DashboardPage />} />
+        <Route path="jobs/:jobId" element={<DashboardPage />} />
+      </Route>
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}
+
+function AppLayout() {
+  const { config } = useAppConfig();
+  const [settingsOpen, setSettingsOpen] = useState<boolean>(!config.apiKey);
+
+  return (
+    <div className="app-shell">
+      <HeaderBar onOpenSettings={() => setSettingsOpen(true)} />
+      <main className="app-main">
+        <Outlet />
+      </main>
+      <SettingsPanel open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+    </div>
+  );
+}
+
+function DashboardPage() {
+  const { config } = useAppConfig();
+  const params = useParams();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const initialJobId = params.jobId || searchParams.get("job") || undefined;
+
+  if (!config.apiKey) {
+    return <AuthPrompt />;
+  }
+
+  return (
+    <Dashboard
+      initialJobId={initialJobId}
+      onNavigateToJob={(jobId) => navigate(`/jobs/${jobId}`)}
+    />
+  );
+}
+
+export default function App() {
+  return (
+    <AppConfigProvider>
+      <AppRoutes />
+    </AppConfigProvider>
+  );
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,0 +1,154 @@
+import { JobArtifacts, JobCreatePayload, JobRecord, JobResponse } from "../types";
+
+export interface ApiConfig {
+  apiBaseUrl: string;
+  apiKey: string;
+}
+
+async function request<T>(
+  path: string,
+  config: ApiConfig,
+  init?: RequestInit
+): Promise<T> {
+  const headers = new Headers(init?.headers);
+  headers.set("Accept", "application/json");
+  if (config.apiKey) {
+    headers.set("X-API-Key", config.apiKey);
+  }
+  const response = await fetch(`${config.apiBaseUrl}${path}`, {
+    ...init,
+    headers,
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `Request failed with status ${response.status}: ${text || response.statusText}`
+    );
+  }
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  const data = (await response.json()) as T;
+  return data;
+}
+
+export async function createJob(
+  payload: JobCreatePayload,
+  config: ApiConfig
+): Promise<JobResponse> {
+  return request<JobResponse>("/jobs", config, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function getJob(jobId: string, config: ApiConfig): Promise<JobRecord> {
+  return request<JobRecord>(`/jobs/${jobId}`, config);
+}
+
+export async function getJobArtifacts(
+  jobId: string,
+  config: ApiConfig
+): Promise<JobArtifacts> {
+  return request<JobArtifacts>(`/jobs/${jobId}/artifacts`, config);
+}
+
+export async function streamJobEvents(
+  jobId: string,
+  config: ApiConfig,
+  signal: AbortSignal,
+  onEvent: (event: MessageEvent<Record<string, unknown>>) => void,
+  onError: (error: Error) => void
+): Promise<void> {
+  try {
+    const response = await fetch(`${config.apiBaseUrl}/jobs/${jobId}/events`, {
+      headers: config.apiKey ? { "X-API-Key": config.apiKey } : undefined,
+      signal,
+    });
+    if (!response.ok || !response.body) {
+      throw new Error(`Unable to open event stream (${response.status})`);
+    }
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!signal.aborted) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      let separatorIndex = buffer.indexOf("\n\n");
+      while (separatorIndex >= 0) {
+        const rawEvent = buffer.slice(0, separatorIndex);
+        buffer = buffer.slice(separatorIndex + 2);
+        const parsed = parseSseEvent(rawEvent);
+        if (parsed) {
+          onEvent(parsed);
+        }
+        separatorIndex = buffer.indexOf("\n\n");
+      }
+    }
+  } catch (error) {
+    if (signal.aborted) {
+      return;
+    }
+    onError(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+interface ParsedEvent {
+  id?: number;
+  event: string;
+  data: Record<string, unknown>;
+  message?: string | null;
+  timestamp?: string;
+}
+
+function parseSseEvent(raw: string): MessageEvent<Record<string, unknown>> | null {
+  if (!raw.trim()) {
+    return null;
+  }
+  const lines = raw.split("\n");
+  let eventName = "message";
+  let id: number | undefined;
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith(":")) {
+      continue;
+    }
+    const [field, ...rest] = line.split(":");
+    const value = rest.join(":").trim();
+    switch (field) {
+      case "event":
+        eventName = value || "message";
+        break;
+      case "id":
+        id = value ? Number(value) : undefined;
+        break;
+      case "data":
+        dataLines.push(value);
+        break;
+    }
+  }
+  const dataText = dataLines.join("\n");
+  let data: Record<string, unknown> = {};
+  if (dataText) {
+    try {
+      data = JSON.parse(dataText);
+    } catch (error) {
+      console.warn("Failed to parse SSE payload", error);
+    }
+  }
+  const event: ParsedEvent = {
+    id,
+    event: eventName,
+    data,
+  };
+  return new MessageEvent<Record<string, unknown>>(eventName, {
+    data: event.data,
+    lastEventId: event.id?.toString(),
+  });
+}

--- a/web/src/components/ArtifactPreview.tsx
+++ b/web/src/components/ArtifactPreview.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { JobArtifacts } from "../types";
+
+interface ArtifactPreviewProps {
+  jobId: string;
+  artifacts: JobArtifacts;
+}
+
+export function ArtifactPreview({ jobId, artifacts }: ArtifactPreviewProps) {
+  const [expandedChunk, setExpandedChunk] = useState<number | null>(null);
+
+  return (
+    <div className="artifact-preview">
+      <section>
+        <h3>Repository map</h3>
+        <textarea value={artifacts.repomap} readOnly rows={12} />
+      </section>
+      <section>
+        <h3>Token summary</h3>
+        {artifacts.token_totals ? (
+          <dl className="token-summary">
+            <div>
+              <dt>Total chunk tokens</dt>
+              <dd>{artifacts.token_totals.chunk_tokens.toLocaleString()}</dd>
+            </div>
+            <div>
+              <dt>Repo map tokens</dt>
+              <dd>{artifacts.token_totals.repo_map_tokens.toLocaleString()}</dd>
+            </div>
+            <div>
+              <dt>Chunk count</dt>
+              <dd>{artifacts.token_totals.chunk_count}</dd>
+            </div>
+          </dl>
+        ) : (
+          <p className="muted">Token counting disabled for this run.</p>
+        )}
+      </section>
+      <section>
+        <h3>Chunks</h3>
+        <div className="chunk-list">
+          {artifacts.chunks.map((chunk) => {
+            const expanded = expandedChunk === chunk.index;
+            return (
+              <details
+                key={chunk.index}
+                open={expanded}
+                onToggle={(event) => {
+                  if ((event.target as HTMLDetailsElement).open) {
+                    setExpandedChunk(chunk.index);
+                  } else {
+                    setExpandedChunk(null);
+                  }
+                }}
+              >
+                <summary>
+                  Chunk {chunk.index} · {chunk.token_count} tokens · {chunk.file_count} files
+                </summary>
+                <pre>{chunk.content}</pre>
+              </details>
+            );
+          })}
+        </div>
+      </section>
+      {artifacts.warnings && artifacts.warnings.length ? (
+        <section>
+          <h3>Warnings</h3>
+          <ul>
+            {artifacts.warnings.map((warning, index) => (
+              <li key={`${jobId}-warning-${index}`}>{warning}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/AuthPrompt.tsx
+++ b/web/src/components/AuthPrompt.tsx
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import { SettingsPanel } from "./SettingsPanel";
+
+export function AuthPrompt() {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="auth-prompt">
+      <h1>Connect to your repo2GPT API</h1>
+      <p>
+        Provide the shared API token configured for the FastAPI service to keep
+        private repositories secure. Credentials are stored in your browser only
+        and reused for subsequent sessions.
+      </p>
+      <button className="btn" onClick={() => setOpen(true)}>
+        Configure connection
+      </button>
+      <SettingsPanel open={open} onClose={() => setOpen(false)} />
+    </div>
+  );
+}

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  JobArtifacts,
+  JobCreatePayload,
+  JobEvent,
+  JobRecord,
+  JobResponse,
+  JobStatus,
+} from "../types";
+import {
+  ApiConfig,
+  createJob,
+  getJob,
+  getJobArtifacts,
+  streamJobEvents,
+} from "../api/client";
+import { useAppConfig } from "../context/AppConfigContext";
+import { JobForm } from "./JobForm";
+import { JobMonitor } from "./JobMonitor";
+
+interface DashboardProps {
+  initialJobId?: string;
+  onNavigateToJob: (jobId: string) => void;
+}
+
+interface JobState {
+  meta?: JobRecord;
+  events: JobEvent[];
+  artifacts?: JobArtifacts;
+  status?: JobStatus;
+  loading: boolean;
+  error?: string | null;
+  eventError?: string | null;
+}
+
+export function Dashboard({ initialJobId, onNavigateToJob }: DashboardProps) {
+  const { config } = useAppConfig();
+  const [jobId, setJobId] = useState<string | undefined>(initialJobId);
+  const [jobState, setJobState] = useState<JobState>({
+    events: [],
+    loading: false,
+  });
+
+  useEffect(() => {
+    setJobId(initialJobId);
+  }, [initialJobId]);
+
+  const apiConfig = useMemo<ApiConfig>(() => ({
+    apiBaseUrl: config.apiBaseUrl,
+    apiKey: config.apiKey,
+  }), [config.apiBaseUrl, config.apiKey]);
+
+  useEffect(() => {
+    if (!jobId) {
+      return;
+    }
+    let cancelled = false;
+    setJobState((state) => ({ ...state, loading: true, error: null }));
+    (async () => {
+      try {
+        const record = await getJob(jobId, apiConfig);
+        if (cancelled) {
+          return;
+        }
+        const events = (record.events || []).map(normalizeEvent);
+        setJobState((state) => ({
+          ...state,
+          meta: record,
+          status: record.status,
+          events,
+          loading: false,
+        }));
+        if (record.status === "completed") {
+          const artifacts = await getJobArtifacts(jobId, apiConfig);
+          if (!cancelled) {
+            setJobState((state) => ({ ...state, artifacts }));
+          }
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setJobState((state) => ({
+            ...state,
+            loading: false,
+            error: error instanceof Error ? error.message : String(error),
+          }));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [jobId, apiConfig]);
+
+  useEffect(() => {
+    if (!jobId) {
+      return;
+    }
+    const controller = new AbortController();
+    streamJobEvents(
+      jobId,
+      apiConfig,
+      controller.signal,
+      (event) => {
+        const payload = event.data as Record<string, unknown>;
+        const normalized = normalizeEvent(payload);
+        if (!normalized.id) {
+          return;
+        }
+        setJobState((state) => {
+          const nextEvents = new Map<number, JobEvent>();
+          state.events.forEach((existing) =>
+            nextEvents.set(existing.id, existing)
+          );
+          nextEvents.set(normalized.id, normalized);
+          const events = Array.from(nextEvents.values()).sort(
+            (a, b) => a.id - b.id
+          );
+          const statusUpdate =
+            normalized.event === "status"
+              ? (normalized.data.status as JobStatus | undefined)
+              : undefined;
+          const updatedMeta = state.meta
+            ? {
+                ...state.meta,
+                status: statusUpdate || state.meta.status,
+                updated_at: normalized.timestamp || state.meta.updated_at,
+              }
+            : state.meta;
+          return {
+            ...state,
+            events,
+            status: statusUpdate || state.status,
+            meta: updatedMeta,
+            eventError: null,
+          };
+        });
+        if (
+          normalized.event === "status" &&
+          (normalized.data.status === "completed" ||
+            normalized.data.status === "failed")
+        ) {
+          if (normalized.data.status === "completed") {
+            getJobArtifacts(jobId, apiConfig)
+              .then((artifacts) => {
+                setJobState((state) => ({ ...state, artifacts }));
+              })
+              .catch((error) => {
+                setJobState((state) => ({
+                  ...state,
+                  eventError: error instanceof Error ? error.message : String(error),
+                }));
+              });
+          }
+        }
+      },
+      (error) =>
+        setJobState((state) => ({
+          ...state,
+          eventError: error.message,
+        }))
+    ).catch((error) => {
+      if (controller.signal.aborted) {
+        return;
+      }
+      setJobState((state) => ({
+        ...state,
+        eventError: error instanceof Error ? error.message : String(error),
+      }));
+    });
+    return () => {
+      controller.abort();
+    };
+  }, [jobId, apiConfig]);
+
+  const handleJobCreated = (response: JobResponse) => {
+    setJobId(response.id);
+    setJobState({
+      meta: undefined,
+      events: [],
+      artifacts: undefined,
+      status: response.status,
+      loading: false,
+      error: null,
+      eventError: null,
+    });
+    onNavigateToJob(response.id);
+  };
+
+  const handleSubmitJob = async (payload: JobCreatePayload) => {
+    const response = await createJob(payload, apiConfig);
+    handleJobCreated(response);
+    return response;
+  };
+
+  return (
+    <div className="dashboard">
+      <section className="panel panel-form">
+        <JobForm onSubmit={handleSubmitJob} busy={jobState.loading && !!jobId} />
+      </section>
+      <section className="panel panel-monitor">
+        <JobMonitor
+          jobId={jobId}
+          jobState={jobState}
+          onRefresh={async () => {
+            if (!jobId) return;
+            setJobState((state) => ({ ...state, loading: true }));
+            try {
+              const record = await getJob(jobId, apiConfig);
+              const events = (record.events || []).map(normalizeEvent);
+              let artifacts: JobArtifacts | undefined;
+              if (record.status === "completed") {
+                artifacts = await getJobArtifacts(jobId, apiConfig);
+              }
+              setJobState((state) => ({
+                ...state,
+                meta: record,
+                status: record.status,
+                events,
+                artifacts: artifacts ?? state.artifacts,
+                loading: false,
+                error: null,
+              }));
+            } catch (error) {
+              setJobState((state) => ({
+                ...state,
+                loading: false,
+                error: error instanceof Error ? error.message : String(error),
+              }));
+            }
+          }}
+        />
+      </section>
+    </div>
+  );
+}
+
+function normalizeEvent(raw: unknown): JobEvent {
+  const event = (raw ?? {}) as Record<string, unknown>;
+  return {
+    id: Number(event.id ?? 0),
+    timestamp: String(event.timestamp ?? ""),
+    event: String(event.event ?? "message"),
+    message: (event.message as string | undefined) || null,
+    data: (event.data as Record<string, unknown>) || {},
+  };
+}

--- a/web/src/components/EventTimeline.tsx
+++ b/web/src/components/EventTimeline.tsx
@@ -1,0 +1,41 @@
+import { JobEvent } from "../types";
+
+interface EventTimelineProps {
+  events: JobEvent[];
+}
+
+export function EventTimeline({ events }: EventTimelineProps) {
+  if (!events.length) {
+    return <p className="muted">No events yet.</p>;
+  }
+  return (
+    <ol className="timeline">
+      {events.map((event) => (
+        <li key={event.id} className={`timeline-event timeline-${event.event}`}>
+          <div className="timeline-meta">
+            <time dateTime={event.timestamp}>{formatTimestamp(event.timestamp)}</time>
+            <span className="timeline-type">{event.event}</span>
+          </div>
+          <div className="timeline-body">
+            <p>{event.message || ""}</p>
+            {Object.keys(event.data || {}).length ? (
+              <pre>{JSON.stringify(event.data, null, 2)}</pre>
+            ) : null}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function formatTimestamp(input: string): string {
+  if (!input) {
+    return "";
+  }
+  try {
+    const date = new Date(input);
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+  } catch (error) {
+    return input;
+  }
+}

--- a/web/src/components/GeminiUploader.tsx
+++ b/web/src/components/GeminiUploader.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useAppConfig } from "../context/AppConfigContext";
+import { JobArtifacts } from "../types";
+import { createArtifactArchive } from "../utils/artifacts";
+
+interface GeminiUploaderProps {
+  jobId: string;
+  artifacts?: JobArtifacts;
+}
+
+export function GeminiUploader({ jobId, artifacts }: GeminiUploaderProps) {
+  const { config } = useAppConfig();
+  const [status, setStatus] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  if (!artifacts) {
+    return null;
+  }
+
+  const handleUpload = async () => {
+    if (!config.geminiApiKey) {
+      setStatus("Configure a Gemini access token in settings first.");
+      return;
+    }
+    setUploading(true);
+    setStatus(null);
+    try {
+      const bundle = await createArtifactArchive(jobId, artifacts);
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/upload/v1beta/files?key=${encodeURIComponent(
+          config.geminiApiKey
+        )}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/zip",
+            "X-Goog-Upload-File-Name": `${jobId}.zip`,
+            "X-Goog-Upload-Protocol": "raw",
+          },
+          body: bundle,
+        }
+      );
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Upload failed (${response.status}): ${text}`);
+      }
+      const json = await response.json();
+      setStatus(`Uploaded as ${json.name || "file"}`);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="gemini-uploader">
+      <button className="btn btn-secondary" onClick={handleUpload} disabled={uploading}>
+        {uploading ? "Uploading to Gemini..." : "Upload bundle to Gemini"}
+      </button>
+      {status ? <p className="muted">{status}</p> : null}
+    </div>
+  );
+}

--- a/web/src/components/HeaderBar.tsx
+++ b/web/src/components/HeaderBar.tsx
@@ -1,0 +1,33 @@
+import { useLocation, Link } from "react-router-dom";
+import { useAppConfig } from "../context/AppConfigContext";
+
+interface HeaderBarProps {
+  onOpenSettings: () => void;
+}
+
+export function HeaderBar({ onOpenSettings }: HeaderBarProps) {
+  const { config } = useAppConfig();
+  const location = useLocation();
+  const jobId = location.pathname.startsWith("/jobs/")
+    ? location.pathname.split("/jobs/")[1]
+    : undefined;
+
+  return (
+    <header className="app-header">
+      <div className="header-content">
+        <Link to="/" className="brand">
+          repo2GPT Control Panel
+        </Link>
+        <div className="header-meta">
+          <span className="endpoint">API: {config.apiBaseUrl}</span>
+          {jobId ? <span className="job-tag">Job {jobId}</span> : null}
+        </div>
+      </div>
+      <div className="header-actions">
+        <button type="button" className="btn" onClick={onOpenSettings}>
+          Settings
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/web/src/components/JobForm.tsx
+++ b/web/src/components/JobForm.tsx
@@ -1,0 +1,322 @@
+import { FormEvent, useMemo, useState } from "react";
+import {
+  ArchiveUploadSourcePayload,
+  JobCreatePayload,
+  JobResponse,
+  SourceType,
+} from "../types";
+
+interface JobFormProps {
+  onSubmit: (payload: JobCreatePayload) => Promise<JobResponse>;
+  busy?: boolean;
+}
+
+interface UploadState extends ArchiveUploadSourcePayload {}
+
+export function JobForm({ onSubmit, busy }: JobFormProps) {
+  const [sourceType, setSourceType] = useState<SourceType>("git");
+  const [gitUrl, setGitUrl] = useState("");
+  const [gitRef, setGitRef] = useState("");
+  const [archiveUrl, setArchiveUrl] = useState("");
+  const [archiveFilename, setArchiveFilename] = useState("");
+  const [upload, setUpload] = useState<UploadState | null>(null);
+  const [ignorePatterns, setIgnorePatterns] = useState(".git\nnode_modules\n.env");
+  const [includePatterns, setIncludePatterns] = useState("");
+  const [allowedExtensions, setAllowedExtensions] = useState("");
+  const [chunkLimit, setChunkLimit] = useState<number | undefined>(undefined);
+  const [enableTokens, setEnableTokens] = useState(true);
+  const [allowNonCode, setAllowNonCode] = useState(false);
+  const [maxFileBytes, setMaxFileBytes] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const options = useMemo(() => {
+    const payload: JobCreatePayload["options"] = {};
+    if (ignorePatterns.trim()) {
+      payload.ignore_patterns = splitLines(ignorePatterns);
+    }
+    if (includePatterns.trim()) {
+      payload.include_patterns = splitLines(includePatterns);
+    }
+    if (allowedExtensions.trim()) {
+      payload.allowed_extensions = splitLines(allowedExtensions);
+    }
+    if (allowNonCode) {
+      payload.allow_non_code = true;
+    }
+    if (maxFileBytes.trim()) {
+      const numeric = Number(maxFileBytes);
+      if (!Number.isNaN(numeric)) {
+        payload.max_file_bytes = numeric;
+      }
+    }
+    return payload;
+  }, [ignorePatterns, includePatterns, allowedExtensions, allowNonCode, maxFileBytes]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const payload: JobCreatePayload = {
+        source: buildSourcePayload(sourceType, {
+          gitUrl,
+          gitRef,
+          archiveUrl,
+          archiveFilename,
+          upload,
+        }),
+        enable_token_counts: enableTokens,
+      };
+      if (Object.keys(options).length > 0) {
+        payload.options = options;
+      }
+      if (chunkLimit) {
+        payload.chunk_token_limit = chunkLimit;
+      }
+      await onSubmit(payload);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onFileSelected = async (fileList: FileList | null) => {
+    if (!fileList || fileList.length === 0) {
+      setUpload(null);
+      return;
+    }
+    const file = fileList[0];
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        const base64 = result.split(",")[1] || "";
+        setUpload({ type: "archive_upload", filename: file.name, content_base64: base64 });
+      }
+    };
+    reader.onerror = () => {
+      setError("Failed to read archive file");
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <form className="job-form" onSubmit={handleSubmit}>
+      <h2>Submit a repository snapshot job</h2>
+      <p className="muted">
+        Provide either a Git URL, a downloadable archive, or upload a local
+        archive. Jobs run asynchronously and stream progress events.
+      </p>
+
+      <fieldset className="field-group">
+        <legend>Source</legend>
+        <div className="field">
+          <label htmlFor="source-select">Source type</label>
+          <select
+            id="source-select"
+            value={sourceType}
+            onChange={(event) => setSourceType(event.target.value as SourceType)}
+          >
+            <option value="git">Git repository URL</option>
+            <option value="archive_url">Archive download URL</option>
+            <option value="archive_upload">Upload archive</option>
+          </select>
+        </div>
+
+        {sourceType === "git" ? (
+          <>
+            <div className="field">
+              <label>Repository URL</label>
+              <input
+                type="url"
+                value={gitUrl}
+                onChange={(event) => setGitUrl(event.target.value)}
+                placeholder="https://github.com/org/repo.git"
+                required
+              />
+            </div>
+            <div className="field">
+              <label>Git reference (branch, tag, commit)</label>
+              <input
+                type="text"
+                value={gitRef}
+                onChange={(event) => setGitRef(event.target.value)}
+                placeholder="main"
+              />
+            </div>
+          </>
+        ) : null}
+
+        {sourceType === "archive_url" ? (
+          <>
+            <div className="field">
+              <label>Archive URL</label>
+              <input
+                type="url"
+                value={archiveUrl}
+                onChange={(event) => setArchiveUrl(event.target.value)}
+                placeholder="https://example.com/archive.tar.gz"
+                required
+              />
+            </div>
+            <div className="field">
+              <label>Save as filename (optional)</label>
+              <input
+                type="text"
+                value={archiveFilename}
+                onChange={(event) => setArchiveFilename(event.target.value)}
+                placeholder="repo.tar.gz"
+              />
+            </div>
+          </>
+        ) : null}
+
+        {sourceType === "archive_upload" ? (
+          <div className="field">
+            <label>Upload tar/zip archive</label>
+            <input
+              type="file"
+              accept=".zip,.tar,.tar.gz,.tgz,.tar.bz2,.tbz,.tar.xz,.txz"
+              onChange={(event) => onFileSelected(event.target.files)}
+              required
+            />
+            {upload ? (
+              <p className="muted">
+                Ready to upload <strong>{upload.filename}</strong>
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </fieldset>
+
+      <fieldset className="field-group">
+        <legend>Processing options</legend>
+        <div className="field">
+          <label>Ignore patterns</label>
+          <textarea
+            value={ignorePatterns}
+            onChange={(event) => setIgnorePatterns(event.target.value)}
+            rows={4}
+          />
+          <small>Newline separated glob patterns.</small>
+        </div>
+        <div className="field">
+          <label>Include patterns</label>
+          <textarea
+            value={includePatterns}
+            onChange={(event) => setIncludePatterns(event.target.value)}
+            rows={2}
+          />
+        </div>
+        <div className="field">
+          <label>Allowed extensions</label>
+          <textarea
+            value={allowedExtensions}
+            onChange={(event) => setAllowedExtensions(event.target.value)}
+            rows={2}
+          />
+        </div>
+        <div className="field-inline">
+          <label>
+            <span>Chunk token limit</span>
+            <input
+              type="number"
+              min={1}
+              value={chunkLimit ?? ""}
+              onChange={(event) =>
+                setChunkLimit(
+                  event.target.value ? Number(event.target.value) : undefined
+                )
+              }
+              placeholder="e.g. 1200"
+            />
+          </label>
+          <label>
+            <span>Max file bytes</span>
+            <input
+              type="number"
+              min={1}
+              value={maxFileBytes}
+              onChange={(event) => setMaxFileBytes(event.target.value)}
+              placeholder="e.g. 200000"
+            />
+          </label>
+        </div>
+        <div className="checkboxes">
+          <label>
+            <input
+              type="checkbox"
+              checked={enableTokens}
+              onChange={(event) => setEnableTokens(event.target.checked)}
+            />
+            Track token counts per chunk
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={allowNonCode}
+              onChange={(event) => setAllowNonCode(event.target.checked)}
+            />
+            Include non-code files
+          </label>
+        </div>
+      </fieldset>
+
+      {error ? <p className="error">{error}</p> : null}
+
+      <div className="form-actions">
+        <button className="btn" type="submit" disabled={busy || submitting}>
+          {busy || submitting ? "Submitting..." : "Submit job"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function splitLines(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function buildSourcePayload(
+  sourceType: SourceType,
+  fields: {
+    gitUrl: string;
+    gitRef: string;
+    archiveUrl: string;
+    archiveFilename: string;
+    upload: UploadState | null;
+  }
+): JobCreatePayload["source"] {
+  switch (sourceType) {
+    case "git":
+      if (!fields.gitUrl) {
+        throw new Error("Repository URL is required");
+      }
+      return {
+        type: "git",
+        url: fields.gitUrl,
+        ref: fields.gitRef || undefined,
+      };
+    case "archive_url":
+      if (!fields.archiveUrl) {
+        throw new Error("Archive URL is required");
+      }
+      return {
+        type: "archive_url",
+        url: fields.archiveUrl,
+        filename: fields.archiveFilename || undefined,
+      };
+    case "archive_upload":
+      if (!fields.upload) {
+        throw new Error("Archive upload is required");
+      }
+      return fields.upload as ArchiveUploadSourcePayload;
+    default:
+      throw new Error(`Unsupported source type: ${sourceType}`);
+  }
+}

--- a/web/src/components/JobMonitor.tsx
+++ b/web/src/components/JobMonitor.tsx
@@ -1,0 +1,133 @@
+import { useMemo, useState } from "react";
+import { ArtifactPreview } from "./ArtifactPreview";
+import { EventTimeline } from "./EventTimeline";
+import { GeminiUploader } from "./GeminiUploader";
+import { createArtifactArchive } from "../utils/artifacts";
+import { JobArtifacts, JobEvent, JobRecord, JobStatus } from "../types";
+
+interface JobMonitorProps {
+  jobId?: string;
+  jobState: {
+    meta?: JobRecord;
+    events: JobEvent[];
+    artifacts?: JobArtifacts;
+    status?: JobStatus;
+    loading: boolean;
+    error?: string | null;
+    eventError?: string | null;
+  };
+  onRefresh: () => void | Promise<void>;
+}
+
+export function JobMonitor({ jobId, jobState, onRefresh }: JobMonitorProps) {
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState(false);
+
+  const shareLink = useMemo(() => {
+    if (!jobId || typeof window === "undefined") {
+      return "";
+    }
+    return `${window.location.origin}/jobs/${jobId}`;
+  }, [jobId]);
+
+  if (!jobId) {
+    return (
+      <div className="job-monitor empty">
+        <p>Select or submit a job to monitor progress and view artifacts.</p>
+      </div>
+    );
+  }
+
+  const handleCopyShareLink = async () => {
+    if (!shareLink) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(shareLink);
+      setCopyStatus("Copied!");
+      setTimeout(() => setCopyStatus(null), 2000);
+    } catch (error) {
+      setCopyStatus("Copy failed");
+    }
+  };
+
+  const handleDownloadArtifacts = async () => {
+    if (!jobState.artifacts) {
+      return;
+    }
+    setDownloading(true);
+    try {
+      const archive = await createArtifactArchive(jobId, jobState.artifacts);
+      const url = URL.createObjectURL(archive);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${jobId}_artifacts.zip`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <div className="job-monitor">
+      <header className="job-header">
+        <div>
+          <h2>Job {jobId}</h2>
+          <p>Status: <strong>{jobState.status ?? jobState.meta?.status}</strong></p>
+          {jobState.meta ? (
+            <p className="muted">
+              Created {formatDate(jobState.meta.created_at)} · Last update {formatDate(jobState.meta.updated_at)}
+            </p>
+          ) : null}
+        </div>
+        <div className="job-actions">
+          <button className="btn btn-secondary" onClick={handleCopyShareLink}>
+            Copy shareable link
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={handleDownloadArtifacts}
+            disabled={!jobState.artifacts || downloading}
+          >
+            {downloading ? "Preparing download..." : "Download bundle"}
+          </button>
+          <button className="btn" onClick={() => onRefresh()} disabled={jobState.loading}>
+            {jobState.loading ? "Refreshing..." : "Refresh"}
+          </button>
+        </div>
+      </header>
+
+      {copyStatus ? <p className="muted">{copyStatus}</p> : null}
+      {jobState.error ? <p className="error">{jobState.error}</p> : null}
+      {jobState.eventError ? <p className="error">{jobState.eventError}</p> : null}
+
+      <section>
+        <h3>Progress events</h3>
+        <EventTimeline events={jobState.events} />
+      </section>
+
+      {jobState.artifacts ? (
+        <section>
+          <h3>Artifacts</h3>
+          <ArtifactPreview jobId={jobId} artifacts={jobState.artifacts} />
+          <GeminiUploader jobId={jobId} artifacts={jobState.artifacts} />
+        </section>
+      ) : (
+        <p className="muted">
+          Artifacts become available once the job completes successfully.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function formatDate(value?: string) {
+  if (!value) {
+    return "";
+  }
+  const date = new Date(value);
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+}

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -1,0 +1,127 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useAppConfig } from "../context/AppConfigContext";
+
+interface SettingsPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
+  const { config, setApiBaseUrl, setApiKey, setGeminiApiKey, resetCredentials } =
+    useAppConfig();
+  const [localBaseUrl, setLocalBaseUrl] = useState(config.apiBaseUrl);
+  const [localApiKey, setLocalApiKey] = useState(config.apiKey);
+  const [localGeminiKey, setLocalGeminiKey] = useState(config.geminiApiKey);
+  const [status, setStatus] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setLocalBaseUrl(config.apiBaseUrl);
+      setLocalApiKey(config.apiKey);
+      setLocalGeminiKey(config.geminiApiKey);
+      setStatus(null);
+    }
+  }, [open, config]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setApiBaseUrl(localBaseUrl.trim());
+    setApiKey(localApiKey.trim());
+    setGeminiApiKey(localGeminiKey.trim());
+    onClose();
+  };
+
+  const handleTestConnection = async () => {
+    setTesting(true);
+    setStatus(null);
+    try {
+      const response = await fetch(`${localBaseUrl.replace(/\/$/, "")}/healthz`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      setStatus("API is reachable");
+    } catch (error) {
+      setStatus(`Connection failed: ${error}`);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="settings-backdrop" role="dialog" aria-modal="true">
+      <div className="settings-panel">
+        <div className="settings-header">
+          <h2>Connection settings</h2>
+          <button className="btn btn-link" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        <form className="settings-form" onSubmit={handleSubmit}>
+          <label className="field">
+            <span>API base URL</span>
+            <input
+              type="url"
+              value={localBaseUrl}
+              onChange={(event) => setLocalBaseUrl(event.target.value)}
+              placeholder="http://localhost:8000"
+              required
+            />
+          </label>
+          <label className="field">
+            <span>API token</span>
+            <input
+              type="password"
+              value={localApiKey}
+              onChange={(event) => setLocalApiKey(event.target.value)}
+              placeholder="Paste API key"
+              required
+            />
+          </label>
+          <label className="field">
+            <span>Gemini access token (optional)</span>
+            <input
+              type="password"
+              value={localGeminiKey}
+              onChange={(event) => setLocalGeminiKey(event.target.value)}
+              placeholder="ya29..."
+            />
+            <small>
+              Stored locally and used to upload artifacts via the Google AI File
+              API.
+            </small>
+          </label>
+          <div className="settings-actions">
+            <button
+              className="btn btn-secondary"
+              type="button"
+              onClick={handleTestConnection}
+              disabled={testing}
+            >
+              {testing ? "Testing..." : "Test connection"}
+            </button>
+            <button className="btn" type="submit">
+              Save
+            </button>
+            <button
+              className="btn btn-link"
+              type="button"
+              onClick={() => {
+                resetCredentials();
+                setLocalApiKey("");
+                setLocalGeminiKey("");
+              }}
+            >
+              Clear credentials
+            </button>
+          </div>
+          {status ? <p className="settings-status">{status}</p> : null}
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web/src/context/AppConfigContext.tsx
+++ b/web/src/context/AppConfigContext.tsx
@@ -1,0 +1,78 @@
+import {
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useMemo,
+} from "react";
+import { ApiConfig } from "../api/client";
+import { useLocalStorage } from "../hooks/useLocalStorage";
+
+export interface AppConfig extends ApiConfig {
+  geminiApiKey: string;
+}
+
+interface AppConfigContextValue {
+  config: AppConfig;
+  setApiBaseUrl: (value: string) => void;
+  setApiKey: (value: string) => void;
+  setGeminiApiKey: (value: string) => void;
+  resetCredentials: () => void;
+}
+
+const defaultBaseUrl =
+  (typeof import.meta !== "undefined" &&
+    (import.meta as any).env?.VITE_API_BASE_URL) ||
+  "http://localhost:8000";
+
+const AppConfigContext = createContext<AppConfigContextValue | undefined>(
+  undefined
+);
+
+export function AppConfigProvider({ children }: PropsWithChildren) {
+  const [apiBaseUrl, setApiBaseUrl] = useLocalStorage<string>(
+    "repo2gpt.apiBaseUrl",
+    defaultBaseUrl
+  );
+  const [apiKey, setApiKey] = useLocalStorage<string>("repo2gpt.apiKey", "");
+  const [geminiApiKey, setGeminiApiKey] = useLocalStorage<string>(
+    "repo2gpt.geminiApiKey",
+    ""
+  );
+
+  const config = useMemo<AppConfig>(() => {
+    const normalizedBaseUrl = apiBaseUrl.replace(/\/$/, "");
+    return {
+      apiBaseUrl: normalizedBaseUrl || defaultBaseUrl,
+      apiKey,
+      geminiApiKey,
+    };
+  }, [apiBaseUrl, apiKey, geminiApiKey]);
+
+  const value = useMemo<AppConfigContextValue>(
+    () => ({
+      config,
+      setApiBaseUrl,
+      setApiKey,
+      setGeminiApiKey,
+      resetCredentials: () => {
+        setApiKey("");
+        setGeminiApiKey("");
+      },
+    }),
+    [config, setApiBaseUrl, setApiKey, setGeminiApiKey]
+  );
+
+  return (
+    <AppConfigContext.Provider value={value}>
+      {children}
+    </AppConfigContext.Provider>
+  );
+}
+
+export function useAppConfig(): AppConfigContextValue {
+  const context = useContext(AppConfigContext);
+  if (!context) {
+    throw new Error("useAppConfig must be used within an AppConfigProvider");
+  }
+  return context;
+}

--- a/web/src/hooks/useLocalStorage.ts
+++ b/web/src/hooks/useLocalStorage.ts
@@ -1,0 +1,34 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+
+export function useLocalStorage<T>(
+  key: string,
+  defaultValue: T
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === "undefined") {
+      return defaultValue;
+    }
+    try {
+      const item = window.localStorage.getItem(key);
+      if (item !== null) {
+        return JSON.parse(item) as T;
+      }
+    } catch (error) {
+      console.warn("Failed to read localStorage", error);
+    }
+    return defaultValue;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.warn("Failed to persist localStorage", error);
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+import "./styles/index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -1,0 +1,310 @@
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 0 1.5rem 2rem;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 0 1rem;
+  gap: 1rem;
+}
+
+.header-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 1.5rem;
+  text-decoration: none;
+}
+
+.header-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.job-tag {
+  background: rgba(59, 130, 246, 0.2);
+  color: #bfdbfe;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+}
+
+.btn {
+  padding: 0.55rem 1.2rem;
+  border-radius: 0.75rem;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0f172a;
+  font-weight: 600;
+  box-shadow: 0 8px 18px rgba(59, 130, 246, 0.35);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.btn-secondary {
+  background: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+  box-shadow: none;
+}
+
+.btn-link {
+  background: none;
+  color: #60a5fa;
+  box-shadow: none;
+  padding: 0.4rem 0.6rem;
+}
+
+.app-main {
+  flex: 1;
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: minmax(320px, 380px) 1fr;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.job-form h2 {
+  margin-top: 0;
+}
+
+.job-form .muted {
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.field-group {
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.field-group legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+}
+
+.field,
+.field-inline label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+input,
+textarea,
+select {
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.55rem 0.75rem;
+  background: rgba(15, 23, 42, 0.75);
+  transition: border 0.2s ease;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.field-inline {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.checkboxes label {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.error {
+  color: #fca5a5;
+}
+
+.muted {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.job-monitor header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.job-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.timeline-event {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(71, 85, 105, 0.5);
+}
+
+.timeline-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.timeline-type {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #93c5fd;
+}
+
+.artifact-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.artifact-preview textarea {
+  width: 100%;
+  min-height: 240px;
+}
+
+.chunk-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chunk-list details {
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(71, 85, 105, 0.4);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.token-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.token-summary div {
+  background: rgba(30, 41, 59, 0.7);
+  padding: 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(71, 85, 105, 0.35);
+}
+
+.settings-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.75);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  z-index: 20;
+}
+
+.settings-panel {
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  width: min(480px, 100%);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 18px 50px rgba(2, 6, 23, 0.7);
+}
+
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.settings-status {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.auth-prompt {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.auth-prompt h1 {
+  font-size: 2rem;
+}
+
+@media (max-width: 1080px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -1,0 +1,46 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e293b 0%, #0f172a 50%, #020617 100%);
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+pre {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+}
+
+details summary {
+  cursor: pointer;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,106 @@
+export type JobStatus = "pending" | "running" | "completed" | "failed";
+
+export interface JobResponse {
+  id: string;
+  status: JobStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface JobResult {
+  repomap_path: string;
+  chunks: Array<{
+    index: number;
+    token_count: number;
+    file_count: number;
+    path: string;
+  }>;
+  warnings?: string[];
+  token_estimator?: {
+    enabled: boolean;
+    strategy: string;
+  };
+  token_totals?: {
+    chunk_tokens: number;
+    repo_map_tokens: number;
+    chunk_count: number;
+  };
+}
+
+export interface JobRecord extends JobResponse {
+  request: Record<string, unknown>;
+  events: JobEvent[];
+  result?: JobResult;
+  error?: string | null;
+}
+
+export interface JobEvent {
+  id: number;
+  timestamp: string;
+  event: string;
+  message?: string | null;
+  data: Record<string, unknown>;
+}
+
+export interface ArtifactChunk {
+  index: number;
+  token_count: number;
+  file_count: number;
+  content: string;
+}
+
+export interface JobArtifacts {
+  repomap: string;
+  chunks: ArtifactChunk[];
+  warnings: string[];
+  token_estimator?: {
+    enabled: boolean;
+    strategy: string;
+  } | null;
+  token_totals?: {
+    chunk_tokens: number;
+    repo_map_tokens: number;
+    chunk_count: number;
+  } | null;
+}
+
+export type SourceType = "git" | "archive_url" | "archive_upload";
+
+export interface GitSourcePayload {
+  type: "git";
+  url: string;
+  ref?: string;
+}
+
+export interface ArchiveUrlSourcePayload {
+  type: "archive_url";
+  url: string;
+  filename?: string;
+}
+
+export interface ArchiveUploadSourcePayload {
+  type: "archive_upload";
+  filename: string;
+  content_base64: string;
+}
+
+export type JobSourcePayload =
+  | GitSourcePayload
+  | ArchiveUrlSourcePayload
+  | ArchiveUploadSourcePayload;
+
+export interface ProcessingOptionsPayload {
+  ignore_patterns?: string[];
+  include_patterns?: string[];
+  allowed_extensions?: string[];
+  special_filenames?: string[];
+  max_file_bytes?: number | null;
+  allow_non_code?: boolean;
+}
+
+export interface JobCreatePayload {
+  source: JobSourcePayload;
+  options?: ProcessingOptionsPayload;
+  chunk_token_limit?: number | null;
+  enable_token_counts?: boolean;
+}

--- a/web/src/utils/artifacts.ts
+++ b/web/src/utils/artifacts.ts
@@ -1,0 +1,28 @@
+import JSZip from "jszip";
+import { JobArtifacts } from "../types";
+
+export async function createArtifactArchive(
+  jobId: string,
+  artifacts: JobArtifacts
+): Promise<Blob> {
+  const zip = new JSZip();
+  zip.file(`repomap_${jobId}.txt`, artifacts.repomap);
+  const chunksFolder = zip.folder("chunks");
+  artifacts.chunks.forEach((chunk) => {
+    const padded = String(chunk.index).padStart(4, "0");
+    chunksFolder?.file(`chunk_${padded}.md`, chunk.content);
+  });
+  if (artifacts.warnings && artifacts.warnings.length > 0) {
+    zip.file(
+      "warnings.txt",
+      artifacts.warnings.map((warning) => `- ${warning}`).join("\n")
+    );
+  }
+  if (artifacts.token_totals) {
+    zip.file(
+      "token_summary.json",
+      JSON.stringify(artifacts.token_totals, null, 2)
+    );
+  }
+  return zip.generateAsync({ type: "blob" });
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.paths.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "node16",
+    "moduleResolution": "node16",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/tsconfig.paths.json
+++ b/web/tsconfig.paths.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {}
+  }
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite/React web dashboard that authenticates with the API key, submits jobs, and streams status/events
- surface artifact previews, token stats, shareable links, Gemini uploads, and ZIP downloads directly in the UI
- document deployment guidance for hosting the API and web UI together across common platforms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6902b60594748321884eceff06483484